### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h2 align="center">
   <a href="https://reolink.com"><img src="./logo.png" alt="Reolink logotype" width="200"></a>
   <br>
-  <i>Home Assistant Reolink addon</i>
+  <i>Reolink custom component for Home Assistant</i>
   <br>
 </h2>
 


### PR DESCRIPTION
Wrong type of Home Assistant component was defined in the docs. 

Fixes #49, although the description of the repository needs to be updated as well (@fwestenberg).