### PR TITLE
Added support for camera.turn_off/on to e.g. be used with a Wi-Fi power socket

### DIFF
--- a/custom_components/reolink_dev/ReolinkPyPi/camera.py
+++ b/custom_components/reolink_dev/ReolinkPyPi/camera.py
@@ -60,7 +60,7 @@ class ReolinkApi(object):
 
         for data in json_data:
             try:
-                if data["cmd"] == "GetDevInfo": 
+                if data["cmd"] == "GetDevInfo":
                     self._device_info = data
 
                 elif data["cmd"] == "GetNetPort":
@@ -68,7 +68,7 @@ class ReolinkApi(object):
                     self._rtspport = data["value"]["NetPort"]["rtspPort"]
                     self._rtmpport = data["value"]["NetPort"]["rtmpPort"]
 
-                elif data["cmd"] == "GetFtp": 
+                elif data["cmd"] == "GetFtp":
                     self._ftp_settings = data
                     if (data["value"]["Ftp"]["schedule"]["enable"] == 1):
                         self._ftp_state = True
@@ -81,7 +81,7 @@ class ReolinkApi(object):
                         self._email_state = True
                     else:
                         self._email_state = False
-                        
+
                 elif data["cmd"] == "GetIrLights":
                     self._ir_settings = data
                     if (data["value"]["IrLights"]["state"] == "Auto"):
@@ -106,21 +106,22 @@ class ReolinkApi(object):
                             _LOGGER.debug(f"Got preset {preset_name} with ID {preset_id}")
                         else:
                             _LOGGER.debug(f"Preset is not enabled: {preset}")
-                
+
                 elif data["cmd"] == "GetAlarm":
                     self._motion_detection_settings = data
                     self._pippo = data
+
                     if (data["value"]["Alarm"]["enable"] == 1):
                         self._motion_detection_state = True
                     else:
                         self._motion_detection_state = False
             except:
-                continue    
+                continue
 
     async def get_motion_state(self):
         body = [{"cmd": "GetMdState", "action": 0, "param":{"channel":self._channel}}]
         param = {"token": self._token}
-        
+
         response = await self.send(body, param)
 
         try:
@@ -132,7 +133,7 @@ class ReolinkApi(object):
                 return self._motion_state
 
             if json_data[0]["value"]["state"] == 1:
-                self._motion_state = True 
+                self._motion_state = True
                 self._last_motion = datetime.datetime.now()
             else:
                 self._motion_state = False
@@ -140,7 +141,7 @@ class ReolinkApi(object):
             self._motion_state = False
 
         return self._motion_state
-    
+
     @property
     async def still_image(self):
         response = await self.send(None, f"?cmd=Snap&channel={self._channel}&token={self._token}", stream=True)
@@ -202,7 +203,7 @@ class ReolinkApi(object):
     async def login(self, username, password):
         body = [{"cmd": "Login", "action": 0, "param": {"User": {"userName": username, "password": password}}}]
         param = {"cmd": "Login", "token": "null"}
-        
+
         response = await self.send(body, param)
 
         try:
@@ -225,6 +226,7 @@ class ReolinkApi(object):
         param = {"cmd": "Logout", "token": self._token}
 
         await self.send(body, param)
+        self._token = None
 
     async def set_ftp(self, enabled):
         await self.get_settings()
@@ -344,6 +346,7 @@ class ReolinkApi(object):
 
         body = [{"cmd":"SetAlarm","action":0,"param": self._motion_detection_settings["value"] }]
         body[0]["param"]["Alarm"]["enable"] = newValue
+
         response = await self.send(body, {"cmd": "SetAlarm", "token": self._token} )
         try:
             json_data = json.loads(response)
@@ -356,10 +359,10 @@ class ReolinkApi(object):
             return False
 
     async def send(self, body, param, stream=False):
-        if (self._token is None and 
+        if (self._token is None and
             (body is None or body[0]["cmd"] != "Login")):
             _LOGGER.info(f"Reolink camera at IP {self._ip} is not logged in")
-            return   
+            return
 
         timeout = aiohttp.ClientTimeout(total=10)
 

--- a/custom_components/reolink_dev/ReolinkPyPi/camera.py
+++ b/custom_components/reolink_dev/ReolinkPyPi/camera.py
@@ -225,8 +225,12 @@ class ReolinkApi(object):
         body = [{"cmd":"Logout","action":0,"param":{}}]
         param = {"cmd": "Logout", "token": self._token}
 
-        await self.send(body, param)
-        self._token = None
+        self.clear_token()
+
+        try:
+            await self.send(body, param)
+        except:
+            _LOGGER.info("Couldn't perform logout. Camera may already be turned off")
 
     async def set_ftp(self, enabled):
         await self.get_settings()

--- a/custom_components/reolink_dev/camera.py
+++ b/custom_components/reolink_dev/camera.py
@@ -217,7 +217,7 @@ class ReolinkCamera(Camera):
     @property
     def supported_features(self):
         """Return supported features."""
-        return SUPPORT_STREAM
+        return SUPPORT_ON_OFF | SUPPORT_STREAM
 
     @property
     def name(self):
@@ -303,6 +303,10 @@ class ReolinkCamera(Camera):
 
         """Return a still image response from the camera."""
         return await self._reolinkSession.snapshot
+
+    @property
+    def is_on(self):
+        return self._state not STATE_OFF
 
     async def async_turn_off(self):
         self._state = STATE_OFF

--- a/custom_components/reolink_dev/camera.py
+++ b/custom_components/reolink_dev/camera.py
@@ -4,7 +4,7 @@ import asyncio
 import voluptuous as vol
 import datetime
 
-from homeassistant.components.camera import Camera, PLATFORM_SCHEMA, SUPPORT_STREAM, ENTITY_IMAGE_URL
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA, SUPPORT_ON_OFF, SUPPORT_STREAM, ENTITY_IMAGE_URL
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv
 

--- a/custom_components/reolink_dev/camera.py
+++ b/custom_components/reolink_dev/camera.py
@@ -306,7 +306,7 @@ class ReolinkCamera(Camera):
 
     @property
     def is_on(self):
-        return self._state not STATE_OFF
+        return self._state is not STATE_OFF
 
     async def async_turn_off(self):
         self._state = STATE_OFF

--- a/custom_components/reolink_dev/services.yaml
+++ b/custom_components/reolink_dev/services.yaml
@@ -67,3 +67,17 @@ disable_motion_detection:
     entity_id:
       description: Name of the Reolink camera entity to set.
       example: 'camera.frontdoor'
+
+turn_off:
+  description: 'Virtually' turns the camera off: Reolink camera have no on/off switch, but this service marks the camera as offline for HA.
+  fields:
+    entity_id:
+      description: Name of the Reolink camera entity to turn off.
+      example: 'camera.frontdoor'
+
+turn_on:
+  description: 'Virtually' turns the camera back on: Reolink camera have no on/off switch, but this service marks the camera as online for HA.
+  fields:
+    entity_id:
+      description: Name of the Reolink camera entity to turn on.
+      example: 'camera.frontdoor'

--- a/custom_components/reolink_dev/services.yaml
+++ b/custom_components/reolink_dev/services.yaml
@@ -69,14 +69,14 @@ disable_motion_detection:
       example: 'camera.frontdoor'
 
 turn_off:
-  description: 'Virtually' turns the camera off: Reolink camera have no on/off switch, but this service marks the camera as offline for HA.
+  description: "'Virtually' turns the camera off: Reolink camera have no on/off switch, but this service marks the camera as offline for HA."
   fields:
     entity_id:
       description: Name of the Reolink camera entity to turn off.
       example: 'camera.frontdoor'
 
 turn_on:
-  description: 'Virtually' turns the camera back on: Reolink camera have no on/off switch, but this service marks the camera as online for HA.
+  description: "'Virtually' turns the camera back on: Reolink camera have no on/off switch, but this service marks the camera as online for HA."
   fields:
     entity_id:
       description: Name of the Reolink camera entity to turn on.


### PR DESCRIPTION
Hey there,

first: This is my first time doing any dev for HA / HA components. So I might not be 100% on track with best practices or how things are correctly handled. But I read through the component and docs a bit and tested around and this actually works for me now without any errors.

**What's the purpose of this change / PR?**
The Reolink cameras do not have any on/off switches, hence this component does not implement the `camera.turn_off` / `camera.turn_on` service callbacks.
However, there is the desire to turn cameras off completely, even if you disable motion detection, disable recording and shielded off the camera from the internet: Some people still feel uncomfortable with a camera on all the time.
But: If you plug your camera into a Wi-Fi socket, you can turn the camera on and off! But of course, this will make the component go nuts and spam exceptions all over HA, because we you just took the camera away without the component telling about it.

**What this PR does**
It implements the `camera.turn_off` / `camera.turn_on` service callbacks and adds a new state "off" to the component. This is basically a "virtual turned off state", as the turn_on/off calls don't actually do any call to the camera to physically turn it off. They just simulate it by setting the state and blocking the component from doing anything until it is turned back on.
This is a little different from other devices out there / supported by HA, in a way that these devices could be turned back on from outside HA. But the Reolink cameras can't, as they can't even be turned off.  That's why it's probably fine to also block `async_update()` to do anything, which usually would detect a change from outside HA.

**What else is required to have the magic work**
Really required: Nothing. With this change, you can just call `camera.turn_off` / `camera.turn_on` and turn the camera off and on.
However, the most common usecase / my usecase is that you turn_off/on based on the state of a switch / power socket.
So you might also want to add two automations to your HA:

```
- id: virtual_turn_off_camera
  alias: "[zzz-Helpers] Turn off camera component if camera socket is turned off"
  trigger:
  - platform: state
    entity_id: switch.living_room_camera_power
    from: "on"
    to: "off"
  condition: []
  action:
  - service: camera.turn_off
    entity_id: camera.living_room_camera

- id: virtual_turn_on_camera
  alias: "[zzz-Helpers] Turn on camera component if camera socket is turned on"
  trigger:
  - platform: state
    entity_id: switch.living_room_camera_power
    to: "off"
    to: "on"
  condition: []
  action:
  - delay: 00:01:00
  - service: camera.turn_on
    entity_id: camera.living_room_camera
```
And to also make turning off/on more convenient, I added the power switch to the entity list of the camera lovelace card: `- switch.living_room_camera_power`

Again: This might not be a nice solution which will actually be merged. But I'm open for feedback / how to improve it. Or feel free to contribute yourself :)

Greetings,

Andy!