### PR TITLE
Solve camera connection lose after reboot

### DIFF
--- a/custom_components/reolink_dev/ReolinkPyPi/camera.py
+++ b/custom_components/reolink_dev/ReolinkPyPi/camera.py
@@ -372,3 +372,6 @@ class ReolinkApi(object):
                 async with session.post(url=self._url, json=body, params=param) as response:
                     json_data = await response.text()
                     return json_data
+
+    def clear_token(self):
+        self._token = None

--- a/custom_components/reolink_dev/camera.py
+++ b/custom_components/reolink_dev/camera.py
@@ -399,6 +399,7 @@ class ReolinkCamera(Camera):
 
         except Exception as ex:
             _LOGGER.error(f"Got exception while fetching the state: {ex}")
+            self._reolinkSession.clear_token()
 
     async def disconnect(self, event):
         _LOGGER.info("Disconnecting from Reolink camera")


### PR DESCRIPTION
Partially solves #60, now it will try to login again after it loses connection  for example after an auto or manual reboot.
It is a partially solution because in my case it doesn't solve the stream source. Maybe we have to close the stream and do another stream connection to solve this issue, it will help if we can detect and only run it when it is a reboot.