### PR TITLE
Fixed VoD retreival

### DIFF
--- a/reolink/camera_api.py
+++ b/reolink/camera_api.py
@@ -422,10 +422,8 @@ class Api:  # pylint: disable=too-many-instance-attributes disable=too-many-publ
         REOLink uses an odd encoding, if the camera provides a / in the filename it needs
         to be encoded with %20
         """
-        if self.protocol == DEFAULT_PROTOCOL:
-            stream_source = f"rtmp://{self._host}:{self._rtmp_port}/vod/{filename.replace('/', '%20')}?channel={self._channel}&stream=0&token={self._token}"
-        else:
-            stream_source = None
+        # VoDs are only available over rtmp, rtsp is not an option
+        stream_source = f"rtmp://{self._host}:{self._rtmp_port}/vod/{filename.replace('/', '%20')}?channel={self._channel}&stream=0&token={self._token}"
 
         return stream_source
 


### PR DESCRIPTION
I forgot to handle if the protocol was not rtmp, and I found out that the VoDs are only available over rtmp so I truncated the code to use only rtmp. This could fix issues with video playback if someone sets their camera to rtsp. I discovered this while testing my thumbnail changes.