### PR TITLE
Correction to how AudioAlarm state is returned depending on scheduleV…

### DIFF
--- a/reolink/camera_api.py
+++ b/reolink/camera_api.py
@@ -749,7 +749,11 @@ class Api:  # pylint: disable=too-many-instance-attributes disable=too-many-publ
                     self._motion_detection_state = data["value"]["Alarm"]["enable"] == 1
                     self._sensitivity_presets = data["value"]["Alarm"]["sens"]
 
-                elif data["cmd"] == "GetAudioAlarm" or data["cmd"] == "GetAudioAlarmV20":
+                elif data["cmd"] == "GetAudioAlarm":
+                    self._audio_alarm_settings = data
+                    self._audio_alarm_state = data["value"]["Audio"]["schedule"]["enable"]
+
+                elif  data["cmd"] == "GetAudioAlarmV20":
                     self._audio_alarm_settings = data
                     self._audio_alarm_state = data["value"]["Audio"]["enable"]
 


### PR DESCRIPTION
…ersion which causes call either to  GetAudioAlarm or GetAudioAlarmV20, json returned differs

Bug Fix to eliminate error caused by incorrect translation of returned state information between GetAudioAlarm (scheduleVersion=0) 
and GetAudioAlarmV20 (scheduleVersion=1)