### PR TITLE
Fixes a lack of checks in get_all_motion_states()

### DIFF
--- a/reolink/camera_api.py
+++ b/reolink/camera_api.py
@@ -606,16 +606,25 @@ class Api:  # pylint: disable=too-many-instance-attributes disable=too-many-publ
                 {"cmd": "GetAiState", "action": 0, "param": {"channel": self._channel}}]
 
         response = await self.send(body)
-        json_data = json.loads(response)
+        if response is None:
+            return False
 
-        if json_data is None:
-            _LOGGER.error(
-                "Unable to get All Motion States at IP %s", self._host
-            )
+        try:
+            json_data = json.loads(response)
+
+            if json_data is None:
+                _LOGGER.error(
+                    "Unable to get All Motion States at IP %s", self._host
+                )
+                self._motion_state = False
+                return self._motion_state
+
+            self.map_json_response(json_data)
+        except (TypeError, json.JSONDecodeError):
+            self.clear_token()
             self._motion_state = False
-            return self._motion_state
 
-        self.map_json_response(json_data)
+        return self._motion_state
 
     async def get_still_image(self):
         """Get the still image."""


### PR DESCRIPTION
Looks like this issue affected the Home Assistant component depending on this lib, issue: https://github.com/fwestenberg/reolink_dev/issues/550

There was definitely an inconsistency between `get_all_motion_states()` and `get_motion_state()` in this code: while `get_motion_state()` checks the response from cameras/NVR, the `get_all_motion_states()` just blindly passed the response to `json.loads()` (which in case of empty response lead to problems in Home Assistant), and never called `clear_token()` which could be a source of Home Assistant problems too...

I'm still testing these changes locally, maybe later I'll find some more fixes that still affect Home Assistant - but this one is **definitely** an issue that asks to be fixed, so I think it would be safe if you'd accept this pull-request...