### PR TITLE
Issue fix: SOAP subscribe request not completely up to standard

### DIFF
--- a/reolink/templates.py
+++ b/reolink/templates.py
@@ -8,67 +8,71 @@ UNSUBSCRIBE_ACTION = {'action': 'http://docs.oasis-open.org/wsn/bw-2/Subscriptio
 
 SUBSCRIBE_XML = '''
     <soap:Envelope xmlns:add="http://www.w3.org/2005/08/addressing" xmlns:b="http://docs.oasis-open.org/wsn/b-2" xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
-    <soap:Header><wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
-    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-    <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
-    <wsse:Username>{Username}</wsse:Username>
-    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
-    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
-    <wsu:Created>{Created}</wsu:Created>
-    </wsse:UsernameToken>
-    </wsse:Security>
-    </soap:Header>
-    <soap:Body>
-        <b:Subscribe>
-            <b:ConsumerReference>
-                <add:Address>{Address}</add:Address>
-            </b:ConsumerReference>
-            <b:InitialTerminationTime>{InitialTerminationTime}</b:InitialTerminationTime>
-        </b:Subscribe>
-    </soap:Body>
+        <soap:Header>
+            <add:Action>http://docs.oasis-open.org/wsn/bw-2/NotificationProducer/SubscribeRequest</add:Action>
+            <wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+                <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
+                    <wsse:Username>{Username}</wsse:Username>
+                    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
+                    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
+                    <wsu:Created>{Created}</wsu:Created>
+                </wsse:UsernameToken>
+            </wsse:Security>
+        </soap:Header>
+        <soap:Body>
+            <b:Subscribe>
+                <b:ConsumerReference>
+                    <add:Address>{Address}</add:Address>
+                </b:ConsumerReference>
+                <b:InitialTerminationTime>{InitialTerminationTime}</b:InitialTerminationTime>
+            </b:Subscribe>
+        </soap:Body>
     </soap:Envelope>
 '''
 
 
 RENEW_XML = '''
     <soap:Envelope xmlns:add="http://www.w3.org/2005/08/addressing" xmlns:b="http://docs.oasis-open.org/wsn/b-2" xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
-    <soap:Header><wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
-    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-    <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
-    <wsse:Username>{Username}</wsse:Username>
-    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
-    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
-    <wsu:Created>{Created}</wsu:Created>
-    </wsse:UsernameToken>
-    </wsse:Security>
-        <add:Action>http://docs.oasis-open.org/wsn/bw-2/SubscriptionManager/RenewRequest</add:Action>
-        <add:To>{To}</add:To>
-    </soap:Header>
-    <soap:Body>
-        <b:Renew>
-            <b:TerminationTime>{TerminationTime}</b:TerminationTime>
-        </b:Renew>
-    </soap:Body>
+        <soap:Header>
+            <add:Action>http://docs.oasis-open.org/wsn/bw-2/SubscriptionManager/RenewRequest</add:Action>
+            <add:To>{To}</add:To>
+            <wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+                <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
+                    <wsse:Username>{Username}</wsse:Username>
+                    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
+                    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
+                    <wsu:Created>{Created}</wsu:Created>
+                </wsse:UsernameToken>
+            </wsse:Security>
+        </soap:Header>
+        <soap:Body>
+            <b:Renew>
+                <b:TerminationTime>{TerminationTime}</b:TerminationTime>
+            </b:Renew>
+        </soap:Body>
     </soap:Envelope>
 '''
 
 
 UNSUBSCRIBE_XML = '''
     <soap:Envelope xmlns:add="http://www.w3.org/2005/08/addressing" xmlns:b="http://docs.oasis-open.org/wsn/b-2" xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
-    <soap:Header><wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
-    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-    <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
-    <wsse:Username>{Username}</wsse:Username>
-    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
-    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
-    <wsu:Created>{Created}</wsu:Created>
-    </wsse:UsernameToken>
-    </wsse:Security>
-        <add:Action>http://docs.oasis-open.org/wsn/bw-2/SubscriptionManager/UnsubscribeRequest</add:Action>
-        <add:To>{To}</add:To>
-    </soap:Header>
-    <soap:Body>
-        <b:Unsubscribe/>
-    </soap:Body>
+        <soap:Header>
+            <add:Action>http://docs.oasis-open.org/wsn/bw-2/SubscriptionManager/UnsubscribeRequest</add:Action>
+            <add:To>{To}</add:To>
+            <wsse:Security soap:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+                <wsse:UsernameToken wsu:Id="UsernameToken-{UsernameToken}">
+                    <wsse:Username>{Username}</wsse:Username>
+                    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">{PasswordDigest}</wsse:Password>
+                    <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">{Nonce}</wsse:Nonce>
+                    <wsu:Created>{Created}</wsu:Created>
+                </wsse:UsernameToken>
+            </wsse:Security>
+        </soap:Header>
+        <soap:Body>
+            <b:Unsubscribe/>
+        </soap:Body>
     </soap:Envelope>
 '''


### PR DESCRIPTION
Still working on https://github.com/fwestenberg/reolink_dev/issues/550

I've found out that the "subscribe" SOAP request in the template did not follow completely the WSN standard. There should have been an "Action" section too. It exists in your other "renew" and "unsubscribe" templates, but looks you've just forgot it in the "subscribe" template...

![1](https://user-images.githubusercontent.com/3421219/187767783-7c9951d1-d10f-4672-90b9-31390c09042b.png)

It could be OK with some devices, but there is no guarantee that some particular cameras/NVRs would not stumble on this and just return the error-400 with `SOAP-ENV:Sender` fail. So IMHO it would be a good thing to do to make this request up-to-standard too...
Plus I've just made a nicer formatting to the other templates too... my OCD just tortured me to do this... :)

The main pull-request finally fixing the unstable subscription issues and logged errors will follow in the `reolink_dev` repo as soon as I finish with all the changes/tests...