### PR TITLE
Add permission and feature checking, improve is_admin

### DIFF
--- a/reolink/camera_api.py
+++ b/reolink/camera_api.py
@@ -7,9 +7,8 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Any
 from . import typings
 from .software_version import SoftwareVersion
-from .exceptions import CredentialsInvalidError, SnapshotIsNotValidFileTypeError, InvalidContentTypeError, ApiError
+from .exceptions import CredentialsInvalidError, InvalidContentTypeError, ApiError
 import traceback
-import re
 
 import asyncio
 import aiohttp

--- a/reolink/camera_api.py
+++ b/reolink/camera_api.py
@@ -880,23 +880,24 @@ class Api:  # pylint: disable=too-many-instance-attributes disable=too-many-publ
         _LOGGER.debug("Failed to login at IP %s.", self._host)
         return False
 
-    async def is_admin(self):
+    def is_admin(self):
         """Check if the user has admin authorisation."""
-        for user in self._users:
-            if user["userName"] == self._username:
-                if user["level"] == "admin":
-                    _LOGGER.debug(
-                        "User %s has authorisation level %s",
-                        self._username,
-                        user["level"],
-                    )
-                else:
-                    _LOGGER.warning(
-                        """User %s has authorisation level %s. Only admin users can change
-                        camera settings! Switches will not work.""",
-                        self._username,
-                        user["level"],
-                    )
+        user = [u for u in self._users if u["userName"] == self._username][0]
+        if user["level"] == "admin":
+            _LOGGER.debug(
+                "User %s has authorisation level %s",
+                self._username,
+                user["level"],
+            )
+            return True
+        else:
+            _LOGGER.warning(
+                """User %s has authorisation level %s. Only admin users can change
+                camera settings! Switches will not work.""",
+                self._username,
+                user["level"],
+            )
+            return False
 
     async def logout(self):
         """Logout from the API."""


### PR DESCRIPTION
Permissions methods are unused for now, but will be in a future PR.

For the `is_admin` changes, the `await` will need to be removed [here](https://github.com/fwestenberg/reolink_dev/blob/f0db93c79f030e86e127fb824bc55bcf627d7086/custom_components/reolink_dev/base.py#L226).
Also, I know that the logging in this method is here for Home Assistant, but ideally I think it should be moved to `reolink_dev` (since it is the actual custom component and `reolink` is the library it uses) and `is_admin` could then simply `return user["level"] == "admin"`.